### PR TITLE
fix: Use empty hash as default options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    custom_seeds (0.2.0)
+    custom_seeds (0.3.1)
       progress_bar (= 1.3.1)
 
 GEM

--- a/lib/custom_seeds/seed_file.rb
+++ b/lib/custom_seeds/seed_file.rb
@@ -25,9 +25,9 @@ module CustomSeeds
     end
 
     def self.options(value = nil)
-      return @options if value.nil?
+      return @options = value if value
 
-      @options = value
+      @options ||= {}
     end
 
     def dry_run?

--- a/lib/custom_seeds/version.rb
+++ b/lib/custom_seeds/version.rb
@@ -1,3 +1,3 @@
 module CustomSeeds
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end


### PR DESCRIPTION
This resolves
```
rails db:seed:advertisements:plans --trace  
** Invoke db:seed:advertisements:plans (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute db:seed:advertisements:plans
rails aborted!
NoMethodError: undefined method `[]' for nil:NilClass
/Users/parnett/.asdf/installs/ruby/3.2.4/lib/ruby/gems/3.2.0/gems/custom_seeds-0.3.0/lib/custom_seeds/seed_file.rb:20:in `initialize'
```